### PR TITLE
Updated Dockerfile to use apt-get, as they're using  older versions of

### DIFF
--- a/raspbian-flume/Dockerfile
+++ b/raspbian-flume/Dockerfile
@@ -2,8 +2,8 @@ FROM resin/rpi-raspbian:wheezy
 MAINTAINER Seungryong Kim <srkim@nm.gist.ac.kr>
 
 #Update & Install wget, vim
-RUN sudo apt update
-RUN sudo apt install -y wget vim iputils-ping net-tools iproute2 dnsutils
+RUN sudo apt-get update
+RUN sudo apt-get install -y wget vim iputils-ping net-tools iproute dnsutils
 
 #Timezone
 RUN cp /usr/share/zoneinfo/Asia/Seoul /etc/localtime

--- a/ubuntu-flume/Dockerfile
+++ b/ubuntu-flume/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:14.04
 MAINTAINER Seungryong Kim <srkim@nm.gist.ac.kr>
 
 #Update & Install wget, vim, ping, ip, ifconfig, dig
-RUN sudo apt update
-RUN sudo apt install -y wget vim iputils-ping net-tools iproute2 dnsutils
+RUN sudo apt-get update
+RUN sudo apt-get install -y wget vim iputils-ping net-tools iproute2 dnsutils
 
 #Timezone
 RUN cp /usr/share/zoneinfo/Asia/Seoul /etc/localtime

--- a/ubuntu-kafka/Dockerfile
+++ b/ubuntu-kafka/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:14.04
 MAINTAINER Seungryong Kim <srkim@nm.gist.ac.kr>
 
 #Update & Install wget
-RUN sudo apt update
-RUN sudo apt install -y wget vim iputils-ping net-tools iproute2 dnsutils
+RUN sudo apt-get update
+RUN sudo apt-get install -y wget vim iputils-ping net-tools iproute2 dnsutils
 
 #Install Oracle JAVA
 RUN sudo mkdir -p /opt


### PR DESCRIPTION
their distributions.

-- Raspbian wheezy-based container doesn't have apt command. (Switched to apt)
-- Raspbian wheezy-based container doesn't have iproute2 package. (Switched to iproute)
-- Ubuntu 14.04-based container shows warning when using apt command. (Switched to apt-get)